### PR TITLE
Remove the use of BitBucket username and password

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,6 @@
 # Here are very important environment variables
 # required by bitbucket_cli.
 
-# The user used here should be granted with
-# enough permissions. See README.md OAuth
-# BITBUCKET_USERNAME=
-# BITBUCKET_PASSWORD=
-
 # If you don't have a dedicated BitBucket App, simply
 # create an OAuth2 Consumer in your BitBucket Settings.
 # BITBUCKET_CLIENT_ID=

--- a/bitbucklet/config.py
+++ b/bitbucklet/config.py
@@ -22,12 +22,7 @@ def generate_empty_bitbucklet_dotenv(overwrite: bool, path: click.Path):
         dotenv.write(cleandoc("""
         # Here are very important environment variables
         # required by bitbucket_cli.
-
-        # The user used here should be granted with
-        # enough permissions. See README.md OAuth
-        BITBUCKET_USERNAME=
-        BITBUCKET_PASSWORD=
-
+        
         # If you don't have a dedicated BitBucket App, simply
         # create an OAuth2 Consumer in your BitBucket Settings.
         BITBUCKET_CLIENT_ID=

--- a/bitbucklet/token.py
+++ b/bitbucklet/token.py
@@ -40,6 +40,14 @@ def get_access_token():
     """
     Obtains BitBucket AccessToken using the Resource Owner Grant Flow.
 
+    Note:
+    ====
+    Previously, bitbucklet requires username and password of the account to get
+    an Access Token. This was done because the Atlasssian document said so.
+
+    However, this is not the case. Using the `client` and `secret` of the OAuth Consumer
+    is enough.
+
     References:
     ====
 
@@ -50,8 +58,6 @@ def get_access_token():
 
     bitbucket_client_id = os.getenv('BITBUCKET_CLIENT_ID')
     bitbucket_client_secret = os.getenv('BITBUCKET_CLIENT_SECRET')
-    username = os.getenv('BITBUCKET_USERNAME')
-    password = os.getenv('BITBUCKET_PASSWORD')
 
     response = requests.post(
         token_url(),
@@ -60,9 +66,7 @@ def get_access_token():
             'Accept': 'application/json'
         },
         data = {
-            'grant_type': 'client_credentials',
-            'username': username,
-            'password': password
+            'grant_type': 'client_credentials'
         }
     )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description = "A small CLI to manage BitBucket Cloud",
     author = "Genzer Hawker",
     author_email = "genzers@gmail.com",
-    version='0.3.0',
+    version='0.3.1',
     py_modules=['bitbucklet.cli'],
     packages = find_packages(),
     install_requires=[


### PR DESCRIPTION
On previous versions, the username and password were thought to
be mandatory to get an Access Token (according to official docs
from Atlasssian).

However, in practice, it seems not to be the case. The OAuth
Consumer's `client_id` and `secret` on the `Authorization` are
enough.